### PR TITLE
Clean up addresses

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -14,9 +14,9 @@ def scrape_icon_rest_xml(base_url, query, debug = false)
   page.search('Application').each do |application|
     application_id = application.at("ApplicationId").inner_text
     info_url = "#{base_url}?id=#{application_id}"
-    address = application.at("Address Line1").inner_text
+    address = clean_whitespace(application.at("Address Line1").inner_text)
     if !application.at('Address Line2').inner_text.empty?
-      address += ", " + application.at("Address Line2").inner_text
+      address += ", " + clean_whitespace(application.at("Address Line2").inner_text)
     end
 
     record = {

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,6 +1,10 @@
 require 'scraperwiki'
 require 'mechanize'
 
+def clean_whitespace(string)
+  string.gsub("\r", ' ').gsub("\n", ' ').squeeze(" ").strip
+end
+
 def scrape_icon_rest_xml(base_url, query, debug = false)
   agent = Mechanize.new
   page = agent.get("#{base_url}?#{query}")

--- a/scraper.rb
+++ b/scraper.rb
@@ -10,7 +10,11 @@ def scrape_icon_rest_xml(base_url, query, debug = false)
   page.search('Application').each do |application|
     application_id = application.at("ApplicationId").inner_text
     info_url = "#{base_url}?id=#{application_id}"
-    address = application.at("Address Line1").inner_text + ", " + application.at("Address Line2").inner_text
+    address = application.at("Address Line1").inner_text
+    if !application.at('Address Line2').inner_text.empty?
+      address += ", " + application.at("Address Line2").inner_text
+    end
+
     record = {
       "council_reference" => application.at("ReferenceNumber").inner_text,
       "description" => application.at("ApplicationDetails").inner_text,

--- a/scraper.rb
+++ b/scraper.rb
@@ -14,6 +14,7 @@ def scrape_icon_rest_xml(base_url, query, debug = false)
   page.search('Application').each do |application|
     application_id = application.at("ApplicationId").inner_text
     info_url = "#{base_url}?id=#{application_id}"
+
     address = clean_whitespace(application.at("Address Line1").inner_text)
     if !application.at('Address Line2').inner_text.empty?
       address += ", " + clean_whitespace(application.at("Address Line2").inner_text)

--- a/scraper.rb
+++ b/scraper.rb
@@ -10,6 +10,7 @@ def scrape_icon_rest_xml(base_url, query, debug = false)
   page.search('Application').each do |application|
     application_id = application.at("ApplicationId").inner_text
     info_url = "#{base_url}?id=#{application_id}"
+    address = application.at("Address Line1").inner_text + ", " + application.at("Address Line2").inner_text
     record = {
       "council_reference" => application.at("ReferenceNumber").inner_text,
       "description" => application.at("ApplicationDetails").inner_text,
@@ -17,9 +18,7 @@ def scrape_icon_rest_xml(base_url, query, debug = false)
       # TODO: There can be multiple addresses per application
       # We can't just create a new application for each address as we would then have multiple applications
       # with the same council_reference which isn't currently allowed.
-      "address" =>
-        application.at("Address Line1").inner_text + ", " +
-        application.at("Address Line2").inner_text,
+      "address" => address,
       "date_scraped" => Date.today.to_s,
       "info_url" => info_url,
       # Can't find a specific url for commenting on applications.


### PR DESCRIPTION
These commits clean up the address field, which is currently adding a messy "," to the end of addresses, and also cleans up the whitespace in it.

Before, if the Address Line2 field was empty, for address it would return:

```
Multiple occupancy\n453-461 Parramatta Road\nLEICHHARDT  NSW  2040                                    ,
```

now it cleans it up to:

```
Multiple occupancy 453-461 Parramatta Road LEICHHARDT NSW 2040
```

I've tested this on three different DA xml feeds:
- http://www.eservices.lmc.nsw.gov.au/ApplicationTracking/Pages/XC.Track/SearchApplication.aspx?id=484425&o=xml
- https://eservices1.warringah.nsw.gov.au/ePlanning/live/Public/XC.Track/SearchApplication.aspx?d=last14days&k=LodgementDate&t=DevApp&o=xml
- http://epb.swan.wa.gov.au/Pages/XC.Track/SearchApplication.aspx?d=thisweek&k=LodgementDate&t=282,281,283&o=xml
