### PR TITLE
Optionally, allow the caller to pass a Mechanize agent.

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -5,11 +5,14 @@ def clean_whitespace(string)
   string.gsub("\r", ' ').gsub("\n", ' ').squeeze(" ").strip
 end
 
-def scrape_icon_rest_xml(base_url, query, debug = false)
-  agent = Mechanize.new
+def scrape_icon_rest_xml(base_url, query, debug = false, agent = nil)
+  agent = Mechanize.new unless agent
   page = agent.get("#{base_url}?#{query}")
+
   # Explicitly interpret as XML
   page = Nokogiri::XML(page.content)
+
+  raise "Can't find any <Application> elements" unless page.search('Application').length > 0
 
   page.search('Application').each do |application|
     application_id = application.at("ApplicationId").inner_text


### PR DESCRIPTION
The caller might need to click through a ToS to get cookies.

While we're here, raise an exception if no <Application>s are found.
